### PR TITLE
Remove GWOT tab now that challenge has ended

### DIFF
--- a/app/[[...tab]]/page.tsx
+++ b/app/[[...tab]]/page.tsx
@@ -7,8 +7,8 @@ import {
   buildGWOTLeaderboard,
 } from "../lib/data";
 
-type Tab = "info" | "ranks" | "challenges" | "gwot";
-const VALID_TABS = new Set(["ranks", "challenges", "gwot"]);
+type Tab = "info" | "ranks" | "challenges";
+const VALID_TABS = new Set(["ranks", "challenges"]);
 
 type Props = {
   params: Promise<{ tab?: string[] }>;
@@ -18,31 +18,27 @@ function parseRoute(segments: string[] = []): {
   tab: Tab;
   showSubmit: boolean;
   showInstall: boolean;
-  showGWOTSubmit: boolean;
 } {
   let tab: Tab = "info";
   let showSubmit = false;
   let showInstall = false;
-  let showGWOTSubmit = false;
 
   for (const seg of segments) {
     if (seg === "submit") {
       showSubmit = true;
     } else if (seg === "install") {
       showInstall = true;
-    } else if (seg === "log-miles") {
-      showGWOTSubmit = true;
     } else if (VALID_TABS.has(seg)) {
       tab = seg as Tab;
     }
   }
 
-  return { tab, showSubmit, showInstall, showGWOTSubmit };
+  return { tab, showSubmit, showInstall };
 }
 
 export default async function Home({ params }: Props) {
   const { tab: segments } = await params;
-  const { tab, showSubmit, showInstall, showGWOTSubmit } = parseRoute(segments);
+  const { tab, showSubmit, showInstall } = parseRoute(segments);
 
   const [submissions, challenges, gwotEntries] = await Promise.all([
     getSubmissions(),
@@ -60,8 +56,6 @@ export default async function Home({ params }: Props) {
       activeTab={tab}
       showSubmit={showSubmit}
       showInstall={showInstall}
-      gwotLeaderboard={gwotLeaderboard}
-      showGWOTSubmit={showGWOTSubmit}
     />
   );
 }

--- a/app/dashboard.tsx
+++ b/app/dashboard.tsx
@@ -19,13 +19,22 @@ import {
   AppleLogo,
   AndroidLogo,
   CheckCircle,
+  PersonSimpleRun,
+  FlagBanner,
 } from "@phosphor-icons/react";
 import { nameToSlug } from "./lib/utils";
 
 type LeaderboardEntry = { name: string; points: number };
 type Challenge = { section: string; activity: string; points: number };
+type GWOTLeaderboardEntry = {
+  name: string;
+  totalMiles: number;
+  walkMiles: number;
+  ruckMiles: number;
+  runMiles: number;
+};
 
-type Tab = "info" | "ranks" | "challenges";
+type Tab = "info" | "ranks" | "challenges" | "gwot";
 
 type Props = {
   leaderboard: LeaderboardEntry[];
@@ -33,16 +42,22 @@ type Props = {
   activeTab: Tab;
   showSubmit: boolean;
   showInstall: boolean;
+  gwotLeaderboard: GWOTLeaderboardEntry[];
+  showGWOTSubmit: boolean;
 };
 
 const TAB_PATHS: Record<Tab, string> = {
   info: "/",
   ranks: "/ranks",
   challenges: "/challenges",
+  gwot: "/gwot",
 };
 
 const FORM_URL =
   "https://docs.google.com/forms/d/e/1FAIpQLScponPxBc3lZmg1sw-xtqTHHaEbio4w3jE_FtgzliIcyq1QDw/viewform?embedded=true";
+
+const GWOT_FORM_URL =
+  "https://docs.google.com/forms/d/e/1FAIpQLScFg_USVwo7NWSZNCWKAz1mw4xwuZNu9cmyWiy7b0oLZyD9Aw/viewform?embedded=true";
 
 const PODIUM_LEVELS = [
   { name: "Bronze", points: 50, color: "text-orange-500", bg: "bg-orange-500" },
@@ -121,6 +136,8 @@ export function Dashboard({
   activeTab,
   showSubmit,
   showInstall,
+  gwotLeaderboard,
+  showGWOTSubmit,
 }: Props) {
   const router = useRouter();
   const isClient = useIsClient();
@@ -217,14 +234,28 @@ export function Dashboard({
                 />
                 Challenges
               </Link>
+              <Link
+                href="/gwot"
+                className={`px-1 py-1 text-sm font-medium transition-all flex items-center gap-1.5 border-b-2 ${
+                  activeTab === "gwot"
+                    ? "text-white border-orange-400"
+                    : "text-slate-400 border-transparent hover:text-slate-200"
+                }`}
+              >
+                <FlagBanner
+                  size={16}
+                  weight={activeTab === "gwot" ? "fill" : "regular"}
+                />
+                GWOT
+              </Link>
             </nav>
           </div>
 
-          {/* Mobile Tabs - 3 tabs */}
+          {/* Mobile Tabs - 4 tabs */}
           <nav className="flex bg-slate-900/50 md:hidden">
             <Link
               href="/"
-              className={`flex-1 py-3 text-sm font-medium transition-all flex items-center justify-center gap-1.5 border-b-2 ${
+              className={`flex-1 py-3 text-xs font-medium transition-all flex flex-col items-center justify-center gap-0.5 border-b-2 ${
                 activeTab === "info"
                   ? "text-white border-orange-400 bg-slate-700/50"
                   : "text-slate-400 border-transparent"
@@ -238,7 +269,7 @@ export function Dashboard({
             </Link>
             <Link
               href="/ranks"
-              className={`flex-1 py-3 text-sm font-medium transition-all flex items-center justify-center gap-1.5 border-b-2 ${
+              className={`flex-1 py-3 text-xs font-medium transition-all flex flex-col items-center justify-center gap-0.5 border-b-2 ${
                 activeTab === "ranks"
                   ? "text-white border-orange-400 bg-slate-700/50"
                   : "text-slate-400 border-transparent"
@@ -252,7 +283,7 @@ export function Dashboard({
             </Link>
             <Link
               href="/challenges"
-              className={`flex-1 py-3 text-sm font-medium transition-all flex items-center justify-center gap-1.5 border-b-2 ${
+              className={`flex-1 py-3 text-xs font-medium transition-all flex flex-col items-center justify-center gap-0.5 border-b-2 ${
                 activeTab === "challenges"
                   ? "text-white border-orange-400 bg-slate-700/50"
                   : "text-slate-400 border-transparent"
@@ -263,6 +294,20 @@ export function Dashboard({
                 weight={activeTab === "challenges" ? "fill" : "regular"}
               />
               Challenges
+            </Link>
+            <Link
+              href="/gwot"
+              className={`flex-1 py-3 text-xs font-medium transition-all flex flex-col items-center justify-center gap-0.5 border-b-2 ${
+                activeTab === "gwot"
+                  ? "text-white border-orange-400 bg-slate-700/50"
+                  : "text-slate-400 border-transparent"
+              }`}
+            >
+              <FlagBanner
+                size={18}
+                weight={activeTab === "gwot" ? "fill" : "regular"}
+              />
+              GWOT
             </Link>
           </nav>
         </div>
@@ -359,18 +404,35 @@ export function Dashboard({
             </div>
           </div>
         )}
+
+        {/* GWOT Tab */}
+        {activeTab === "gwot" && (
+          <div className="space-y-4">
+            <GWOTContent gwotLeaderboard={gwotLeaderboard} />
+          </div>
+        )}
       </main>
 
       {/* Fixed Submit Button */}
       <div className="fixed bottom-0 left-0 right-0 p-4 bg-gradient-to-t from-slate-100 via-slate-100 to-transparent pt-8">
         <div className="max-w-md mx-auto">
-          <Link
-            href={submitPath}
-            className="w-full bg-gradient-to-r from-orange-500 to-orange-600 text-white font-semibold py-4 rounded-xl text-lg active:scale-[0.98] transition-transform shadow-lg shadow-orange-500/25 flex items-center justify-center gap-2 hover:from-orange-600 hover:to-orange-700"
-          >
-            <PaperPlaneTilt size={22} weight="fill" />
-            Submit Challenge
-          </Link>
+          {activeTab === "gwot" ? (
+            <Link
+              href="/gwot/log-miles"
+              className="w-full bg-gradient-to-r from-green-500 to-green-600 text-white font-semibold py-4 rounded-xl text-lg active:scale-[0.98] transition-transform shadow-lg shadow-green-500/25 flex items-center justify-center gap-2 hover:from-green-600 hover:to-green-700"
+            >
+              <PersonSimpleRun size={22} weight="fill" />
+              Log Miles
+            </Link>
+          ) : (
+            <Link
+              href={submitPath}
+              className="w-full bg-gradient-to-r from-orange-500 to-orange-600 text-white font-semibold py-4 rounded-xl text-lg active:scale-[0.98] transition-transform shadow-lg shadow-orange-500/25 flex items-center justify-center gap-2 hover:from-orange-600 hover:to-orange-700"
+            >
+              <PaperPlaneTilt size={22} weight="fill" />
+              Submit Challenge
+            </Link>
+          )}
         </div>
       </div>
 
@@ -408,6 +470,36 @@ export function Dashboard({
           platform={platform}
           onDismiss={handleInstallDismiss}
         />
+      )}
+
+      {/* GWOT Submit Modal */}
+      {showGWOTSubmit && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center md:bg-black/50 md:p-8">
+          <div className="bg-white w-full h-full md:w-full md:max-w-2xl md:h-[90vh] md:rounded-2xl md:overflow-hidden flex flex-col">
+            {/* Modal Header */}
+            <div className="flex items-center justify-between p-4 border-b bg-green-700 text-white md:rounded-t-2xl">
+              <div className="flex items-center gap-2">
+                <PersonSimpleRun size={20} weight="fill" />
+                <h2 className="font-semibold">Log Miles</h2>
+              </div>
+              <Link
+                href="/gwot"
+                className="p-2 -m-2 text-green-200 hover:text-white transition-colors"
+              >
+                <X size={24} weight="bold" />
+              </Link>
+            </div>
+
+            {/* Form iframe */}
+            <iframe
+              src={GWOT_FORM_URL}
+              className="flex-1 w-full border-0"
+              title="Log Miles Form"
+            >
+              Loading...
+            </iframe>
+          </div>
+        </div>
       )}
     </div>
   );
@@ -889,5 +981,159 @@ function InstallInstructionsModal({
         </div>
       </div>
     </div>
+  );
+}
+
+// GWOT Content Component
+function GWOTContent({
+  gwotLeaderboard,
+}: {
+  gwotLeaderboard: GWOTLeaderboardEntry[];
+}) {
+  return (
+    <>
+      {/* Hero Card */}
+      <div className="bg-gradient-to-br from-green-700 to-green-800 rounded-2xl p-5 text-white shadow-lg">
+        <div className="flex items-center gap-2 mb-2">
+          <FlagBanner size={24} weight="fill" />
+          <h1 className="text-lg font-bold">GWOT 100 Mile Challenge</h1>
+        </div>
+        <p className="text-green-100 leading-relaxed">
+          Complete 100 miles by February 28th to earn{" "}
+          <strong className="text-white">+10 Iron Clad Points</strong>.
+        </p>
+        <p className="text-green-300 text-sm mt-2">
+          Walk, ruck, or run - every mile counts!
+        </p>
+      </div>
+
+      {/* Mile Leaders */}
+      <div className="bg-white rounded-2xl shadow-sm overflow-hidden">
+        <div className="px-4 py-3 bg-slate-50 border-b border-slate-100 flex items-center gap-2">
+          <Trophy size={16} className="text-slate-400" />
+          <h2 className="text-xs font-semibold text-slate-500 uppercase tracking-wider">
+            Mile Leaders
+          </h2>
+        </div>
+
+        {gwotLeaderboard.length === 0 ? (
+          <div className="p-8 text-center">
+            <div className="w-12 h-12 bg-slate-100 rounded-full flex items-center justify-center mx-auto mb-3">
+              <PersonSimpleRun size={24} className="text-slate-300" />
+            </div>
+            <p className="text-slate-500">No miles logged yet</p>
+            <p className="text-slate-400 text-sm mt-1">Be the first to log!</p>
+          </div>
+        ) : (
+          <div className="divide-y divide-slate-100 max-h-[400px] overflow-y-auto">
+            {gwotLeaderboard.map((entry, i) => {
+              const percent = Math.min(100, (entry.totalMiles / 100) * 100);
+              const completed = entry.totalMiles >= 100;
+              const walkPercent = (entry.walkMiles / 100) * 100;
+              const ruckPercent = (entry.ruckMiles / 100) * 100;
+              const runPercent = (entry.runMiles / 100) * 100;
+
+              return (
+                <div key={entry.name} className="px-4 py-3">
+                  <div className="flex items-center gap-3 mb-2">
+                    <div
+                      className={`w-8 h-8 rounded-full flex items-center justify-center font-bold text-sm ${
+                        i === 0
+                          ? "bg-yellow-100 text-yellow-600"
+                          : i === 1
+                            ? "bg-slate-200 text-slate-600"
+                            : i === 2
+                              ? "bg-orange-100 text-orange-600"
+                              : "bg-slate-100 text-slate-500"
+                      }`}
+                    >
+                      {i + 1}
+                    </div>
+                    <div className="flex-1 min-w-0">
+                      <Link
+                        href={`/profile/${nameToSlug(entry.name)}`}
+                        className="font-medium text-slate-800 truncate hover:text-green-600 transition-colors"
+                      >
+                        {entry.name}
+                      </Link>
+                    </div>
+                    <div className="text-right flex items-center gap-2">
+                      {completed && (
+                        <span className="bg-green-100 text-green-700 text-xs font-semibold px-2 py-0.5 rounded-full">
+                          +10 pts
+                        </span>
+                      )}
+                      <div>
+                        <div className="font-bold text-slate-800">
+                          {entry.totalMiles.toFixed(1)}
+                        </div>
+                        <div className="text-xs text-slate-400">miles</div>
+                      </div>
+                    </div>
+                  </div>
+
+                  {/* Stacked progress bar */}
+                  <div className="h-2 bg-slate-100 rounded-full overflow-hidden flex">
+                    {entry.walkMiles > 0 && (
+                      <div
+                        className="h-full bg-green-500"
+                        style={{ width: `${Math.min(walkPercent, 100)}%` }}
+                        title={`Walk: ${entry.walkMiles.toFixed(1)} mi`}
+                      />
+                    )}
+                    {entry.ruckMiles > 0 && (
+                      <div
+                        className="h-full bg-blue-500"
+                        style={{
+                          width: `${Math.min(ruckPercent, 100 - walkPercent)}%`,
+                        }}
+                        title={`Ruck: ${entry.ruckMiles.toFixed(1)} mi`}
+                      />
+                    )}
+                    {entry.runMiles > 0 && (
+                      <div
+                        className="h-full bg-orange-500"
+                        style={{
+                          width: `${Math.min(runPercent, 100 - walkPercent - ruckPercent)}%`,
+                        }}
+                        title={`Run: ${entry.runMiles.toFixed(1)} mi`}
+                      />
+                    )}
+                  </div>
+
+                  <div className="flex justify-between mt-1">
+                    <span className="text-xs text-slate-400">
+                      {percent.toFixed(0)}% complete
+                    </span>
+                    <span className="text-xs text-slate-400">100 mi goal</span>
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        )}
+      </div>
+
+      {/* Activity Type Legend */}
+      <div className="bg-white rounded-2xl p-4 shadow-sm">
+        <h2 className="text-xs font-semibold text-slate-500 uppercase tracking-wider mb-3">
+          Activity Types
+        </h2>
+        <div className="flex justify-around">
+          <div className="flex items-center gap-2">
+            <div className="w-3 h-3 rounded-full bg-green-500" />
+            <span className="text-sm text-slate-600">Walk</span>
+          </div>
+          <div className="flex items-center gap-2">
+            <div className="w-3 h-3 rounded-full bg-blue-500" />
+            <span className="text-sm text-slate-600">Ruck</span>
+          </div>
+          <div className="flex items-center gap-2">
+            <div className="w-3 h-3 rounded-full bg-orange-500" />
+            <span className="text-sm text-slate-600">Run</span>
+          </div>
+        </div>
+      </div>
+    </>
   );
 }

--- a/app/dashboard.tsx
+++ b/app/dashboard.tsx
@@ -990,6 +990,14 @@ function GWOTContent({
 }: {
   gwotLeaderboard: GWOTLeaderboardEntry[];
 }) {
+  const challengeStart = new Date(2026, 1, 1); // Feb 1, 2026
+  const now = new Date();
+  const daysSinceStart = Math.floor(
+    (now.getTime() - challengeStart.getTime()) / (1000 * 60 * 60 * 24)
+  );
+  const daysElapsed = Math.max(1, Math.min(28, daysSinceStart));
+  const expectedMiles = daysElapsed * (100 / 28);
+
   return (
     <>
       {/* Hero Card */}
@@ -1102,9 +1110,23 @@ function GWOTContent({
                   </div>
 
                   <div className="flex justify-between mt-1">
-                    <span className="text-xs text-slate-400">
-                      {percent.toFixed(0)}% complete
-                    </span>
+                    <div className="flex items-center gap-2">
+                      <span className="text-xs text-slate-400">
+                        {percent.toFixed(0)}% complete
+                      </span>
+                      {!completed && (() => {
+                        const net = entry.totalMiles - expectedMiles;
+                        return net >= 0 ? (
+                          <span className="text-xs text-green-600">
+                            +{net.toFixed(1)} mi ahead of pace
+                          </span>
+                        ) : (
+                          <span className="text-xs text-red-500">
+                            {Math.abs(net).toFixed(1)} mi behind pace
+                          </span>
+                        );
+                      })()}
+                    </div>
                     <span className="text-xs text-slate-400">100 mi goal</span>
                   </div>
                 </div>

--- a/app/dashboard.tsx
+++ b/app/dashboard.tsx
@@ -19,22 +19,13 @@ import {
   AppleLogo,
   AndroidLogo,
   CheckCircle,
-  PersonSimpleRun,
-  FlagBanner,
 } from "@phosphor-icons/react";
 import { nameToSlug } from "./lib/utils";
 
 type LeaderboardEntry = { name: string; points: number };
 type Challenge = { section: string; activity: string; points: number };
-type GWOTLeaderboardEntry = {
-  name: string;
-  totalMiles: number;
-  walkMiles: number;
-  ruckMiles: number;
-  runMiles: number;
-};
 
-type Tab = "info" | "ranks" | "challenges" | "gwot";
+type Tab = "info" | "ranks" | "challenges";
 
 type Props = {
   leaderboard: LeaderboardEntry[];
@@ -42,22 +33,16 @@ type Props = {
   activeTab: Tab;
   showSubmit: boolean;
   showInstall: boolean;
-  gwotLeaderboard: GWOTLeaderboardEntry[];
-  showGWOTSubmit: boolean;
 };
 
 const TAB_PATHS: Record<Tab, string> = {
   info: "/",
   ranks: "/ranks",
   challenges: "/challenges",
-  gwot: "/gwot",
 };
 
 const FORM_URL =
   "https://docs.google.com/forms/d/e/1FAIpQLScponPxBc3lZmg1sw-xtqTHHaEbio4w3jE_FtgzliIcyq1QDw/viewform?embedded=true";
-
-const GWOT_FORM_URL =
-  "https://docs.google.com/forms/d/e/1FAIpQLScFg_USVwo7NWSZNCWKAz1mw4xwuZNu9cmyWiy7b0oLZyD9Aw/viewform?embedded=true";
 
 const PODIUM_LEVELS = [
   { name: "Bronze", points: 50, color: "text-orange-500", bg: "bg-orange-500" },
@@ -136,8 +121,6 @@ export function Dashboard({
   activeTab,
   showSubmit,
   showInstall,
-  gwotLeaderboard,
-  showGWOTSubmit,
 }: Props) {
   const router = useRouter();
   const isClient = useIsClient();
@@ -234,20 +217,6 @@ export function Dashboard({
                 />
                 Challenges
               </Link>
-              <Link
-                href="/gwot"
-                className={`px-1 py-1 text-sm font-medium transition-all flex items-center gap-1.5 border-b-2 ${
-                  activeTab === "gwot"
-                    ? "text-white border-orange-400"
-                    : "text-slate-400 border-transparent hover:text-slate-200"
-                }`}
-              >
-                <FlagBanner
-                  size={16}
-                  weight={activeTab === "gwot" ? "fill" : "regular"}
-                />
-                GWOT
-              </Link>
             </nav>
           </div>
 
@@ -294,20 +263,6 @@ export function Dashboard({
                 weight={activeTab === "challenges" ? "fill" : "regular"}
               />
               Challenges
-            </Link>
-            <Link
-              href="/gwot"
-              className={`flex-1 py-3 text-xs font-medium transition-all flex flex-col items-center justify-center gap-0.5 border-b-2 ${
-                activeTab === "gwot"
-                  ? "text-white border-orange-400 bg-slate-700/50"
-                  : "text-slate-400 border-transparent"
-              }`}
-            >
-              <FlagBanner
-                size={18}
-                weight={activeTab === "gwot" ? "fill" : "regular"}
-              />
-              GWOT
             </Link>
           </nav>
         </div>
@@ -405,34 +360,18 @@ export function Dashboard({
           </div>
         )}
 
-        {/* GWOT Tab */}
-        {activeTab === "gwot" && (
-          <div className="space-y-4">
-            <GWOTContent gwotLeaderboard={gwotLeaderboard} />
-          </div>
-        )}
       </main>
 
       {/* Fixed Submit Button */}
       <div className="fixed bottom-0 left-0 right-0 p-4 bg-gradient-to-t from-slate-100 via-slate-100 to-transparent pt-8">
         <div className="max-w-md mx-auto">
-          {activeTab === "gwot" ? (
-            <Link
-              href="/gwot/log-miles"
-              className="w-full bg-gradient-to-r from-green-500 to-green-600 text-white font-semibold py-4 rounded-xl text-lg active:scale-[0.98] transition-transform shadow-lg shadow-green-500/25 flex items-center justify-center gap-2 hover:from-green-600 hover:to-green-700"
-            >
-              <PersonSimpleRun size={22} weight="fill" />
-              Log Miles
-            </Link>
-          ) : (
-            <Link
-              href={submitPath}
-              className="w-full bg-gradient-to-r from-orange-500 to-orange-600 text-white font-semibold py-4 rounded-xl text-lg active:scale-[0.98] transition-transform shadow-lg shadow-orange-500/25 flex items-center justify-center gap-2 hover:from-orange-600 hover:to-orange-700"
-            >
-              <PaperPlaneTilt size={22} weight="fill" />
-              Submit Challenge
-            </Link>
-          )}
+          <Link
+            href={submitPath}
+            className="w-full bg-gradient-to-r from-orange-500 to-orange-600 text-white font-semibold py-4 rounded-xl text-lg active:scale-[0.98] transition-transform shadow-lg shadow-orange-500/25 flex items-center justify-center gap-2 hover:from-orange-600 hover:to-orange-700"
+          >
+            <PaperPlaneTilt size={22} weight="fill" />
+            Submit Challenge
+          </Link>
         </div>
       </div>
 
@@ -472,35 +411,6 @@ export function Dashboard({
         />
       )}
 
-      {/* GWOT Submit Modal */}
-      {showGWOTSubmit && (
-        <div className="fixed inset-0 z-50 flex items-center justify-center md:bg-black/50 md:p-8">
-          <div className="bg-white w-full h-full md:w-full md:max-w-2xl md:h-[90vh] md:rounded-2xl md:overflow-hidden flex flex-col">
-            {/* Modal Header */}
-            <div className="flex items-center justify-between p-4 border-b bg-green-700 text-white md:rounded-t-2xl">
-              <div className="flex items-center gap-2">
-                <PersonSimpleRun size={20} weight="fill" />
-                <h2 className="font-semibold">Log Miles</h2>
-              </div>
-              <Link
-                href="/gwot"
-                className="p-2 -m-2 text-green-200 hover:text-white transition-colors"
-              >
-                <X size={24} weight="bold" />
-              </Link>
-            </div>
-
-            {/* Form iframe */}
-            <iframe
-              src={GWOT_FORM_URL}
-              className="flex-1 w-full border-0"
-              title="Log Miles Form"
-            >
-              Loading...
-            </iframe>
-          </div>
-        </div>
-      )}
     </div>
   );
 }
@@ -984,178 +894,3 @@ function InstallInstructionsModal({
   );
 }
 
-// GWOT Content Component
-function GWOTContent({
-  gwotLeaderboard,
-}: {
-  gwotLeaderboard: GWOTLeaderboardEntry[];
-}) {
-  const challengeStart = new Date(2026, 1, 1); // Feb 1, 2026
-  const now = new Date();
-  const daysSinceStart = Math.floor(
-    (now.getTime() - challengeStart.getTime()) / (1000 * 60 * 60 * 24)
-  );
-  const daysElapsed = Math.max(1, Math.min(28, daysSinceStart));
-  const expectedMiles = daysElapsed * (100 / 28);
-
-  return (
-    <>
-      {/* Hero Card */}
-      <div className="bg-gradient-to-br from-green-700 to-green-800 rounded-2xl p-5 text-white shadow-lg">
-        <div className="flex items-center gap-2 mb-2">
-          <FlagBanner size={24} weight="fill" />
-          <h1 className="text-lg font-bold">GWOT 100 Mile Challenge</h1>
-        </div>
-        <p className="text-green-100 leading-relaxed">
-          Complete 100 miles by February 28th to earn{" "}
-          <strong className="text-white">+10 Iron Clad Points</strong>.
-        </p>
-        <p className="text-green-300 text-sm mt-2">
-          Walk, ruck, or run - every mile counts!
-        </p>
-      </div>
-
-      {/* Mile Leaders */}
-      <div className="bg-white rounded-2xl shadow-sm overflow-hidden">
-        <div className="px-4 py-3 bg-slate-50 border-b border-slate-100 flex items-center gap-2">
-          <Trophy size={16} className="text-slate-400" />
-          <h2 className="text-xs font-semibold text-slate-500 uppercase tracking-wider">
-            Mile Leaders
-          </h2>
-        </div>
-
-        {gwotLeaderboard.length === 0 ? (
-          <div className="p-8 text-center">
-            <div className="w-12 h-12 bg-slate-100 rounded-full flex items-center justify-center mx-auto mb-3">
-              <PersonSimpleRun size={24} className="text-slate-300" />
-            </div>
-            <p className="text-slate-500">No miles logged yet</p>
-            <p className="text-slate-400 text-sm mt-1">Be the first to log!</p>
-          </div>
-        ) : (
-          <div className="divide-y divide-slate-100 max-h-[400px] overflow-y-auto">
-            {gwotLeaderboard.map((entry, i) => {
-              const percent = Math.min(100, (entry.totalMiles / 100) * 100);
-              const completed = entry.totalMiles >= 100;
-              const walkPercent = (entry.walkMiles / 100) * 100;
-              const ruckPercent = (entry.ruckMiles / 100) * 100;
-              const runPercent = (entry.runMiles / 100) * 100;
-
-              return (
-                <div key={entry.name} className="px-4 py-3">
-                  <div className="flex items-center gap-3 mb-2">
-                    <div
-                      className={`w-8 h-8 rounded-full flex items-center justify-center font-bold text-sm ${
-                        i === 0
-                          ? "bg-yellow-100 text-yellow-600"
-                          : i === 1
-                            ? "bg-slate-200 text-slate-600"
-                            : i === 2
-                              ? "bg-orange-100 text-orange-600"
-                              : "bg-slate-100 text-slate-500"
-                      }`}
-                    >
-                      {i + 1}
-                    </div>
-                    <div className="flex-1 min-w-0">
-                      <Link
-                        href={`/profile/${nameToSlug(entry.name)}`}
-                        className="font-medium text-slate-800 truncate hover:text-green-600 transition-colors"
-                      >
-                        {entry.name}
-                      </Link>
-                    </div>
-                    <div className="text-right flex items-center gap-2">
-                      {completed && (
-                        <span className="bg-green-100 text-green-700 text-xs font-semibold px-2 py-0.5 rounded-full">
-                          +10 pts
-                        </span>
-                      )}
-                      <div>
-                        <div className="font-bold text-slate-800">
-                          {entry.totalMiles.toFixed(1)}
-                        </div>
-                        <div className="text-xs text-slate-400">miles</div>
-                      </div>
-                    </div>
-                  </div>
-
-                  {/* Stacked progress bar */}
-                  <div className="h-2 bg-slate-100 rounded-full overflow-hidden flex">
-                    {entry.walkMiles > 0 && (
-                      <div
-                        className="h-full bg-green-500"
-                        style={{ width: `${Math.min(walkPercent, 100)}%` }}
-                        title={`Walk: ${entry.walkMiles.toFixed(1)} mi`}
-                      />
-                    )}
-                    {entry.ruckMiles > 0 && (
-                      <div
-                        className="h-full bg-blue-500"
-                        style={{
-                          width: `${Math.min(ruckPercent, 100 - walkPercent)}%`,
-                        }}
-                        title={`Ruck: ${entry.ruckMiles.toFixed(1)} mi`}
-                      />
-                    )}
-                    {entry.runMiles > 0 && (
-                      <div
-                        className="h-full bg-orange-500"
-                        style={{
-                          width: `${Math.min(runPercent, 100 - walkPercent - ruckPercent)}%`,
-                        }}
-                        title={`Run: ${entry.runMiles.toFixed(1)} mi`}
-                      />
-                    )}
-                  </div>
-
-                  <div className="flex justify-between mt-1">
-                    <div className="flex items-center gap-2">
-                      <span className="text-xs text-slate-400">
-                        {percent.toFixed(0)}% complete
-                      </span>
-                      {!completed && (() => {
-                        const net = entry.totalMiles - expectedMiles;
-                        return net >= 0 ? (
-                          <span className="text-xs text-green-600">
-                            +{net.toFixed(1)} mi ahead of pace
-                          </span>
-                        ) : (
-                          <span className="text-xs text-red-500">
-                            {Math.abs(net).toFixed(1)} mi behind pace
-                          </span>
-                        );
-                      })()}
-                    </div>
-                    <span className="text-xs text-slate-400">100 mi goal</span>
-                  </div>
-                </div>
-              );
-            })}
-          </div>
-        )}
-      </div>
-
-      {/* Activity Type Legend */}
-      <div className="bg-white rounded-2xl p-4 shadow-sm">
-        <h2 className="text-xs font-semibold text-slate-500 uppercase tracking-wider mb-3">
-          Activity Types
-        </h2>
-        <div className="flex justify-around">
-          <div className="flex items-center gap-2">
-            <div className="w-3 h-3 rounded-full bg-green-500" />
-            <span className="text-sm text-slate-600">Walk</span>
-          </div>
-          <div className="flex items-center gap-2">
-            <div className="w-3 h-3 rounded-full bg-blue-500" />
-            <span className="text-sm text-slate-600">Ruck</span>
-          </div>
-          <div className="flex items-center gap-2">
-            <div className="w-3 h-3 rounded-full bg-orange-500" />
-            <span className="text-sm text-slate-600">Run</span>
-          </div>
-        </div>
-      </div>
-    </>
-  );
-}

--- a/app/lib/data.ts
+++ b/app/lib/data.ts
@@ -2,6 +2,8 @@ export const SUBMISSIONS_CSV_URL =
   "https://docs.google.com/spreadsheets/d/1M3u3t2TzVcJptUyfipu3IR8SExpFqIzHEeEQRoX7_-E/export?format=csv&gid=319550974";
 export const CHALLENGES_CSV_URL =
   "https://docs.google.com/spreadsheets/d/1M3u3t2TzVcJptUyfipu3IR8SExpFqIzHEeEQRoX7_-E/export?format=csv&gid=1131610114";
+export const GWOT_MILES_CSV_URL =
+  "https://docs.google.com/spreadsheets/d/1M3u3t2TzVcJptUyfipu3IR8SExpFqIzHEeEQRoX7_-E/export?format=csv&gid=744579582";
 
 export type Submission = {
   name: string;
@@ -12,6 +14,22 @@ export type Submission = {
 };
 export type Challenge = { section: string; activity: string; points: number };
 export type LeaderboardEntry = { name: string; points: number };
+
+export type GWOTMileEntry = {
+  name: string;
+  date: string;
+  activityType: "Walk" | "Ruck" | "Run";
+  miles: number;
+  notes: string;
+};
+
+export type GWOTLeaderboardEntry = {
+  name: string;
+  totalMiles: number;
+  walkMiles: number;
+  ruckMiles: number;
+  runMiles: number;
+};
 
 export async function fetchCSV(url: string): Promise<string[][]> {
   const res = await fetch(url, { next: { revalidate: 60 } });
@@ -48,9 +66,53 @@ export async function getChallenges(): Promise<Challenge[]> {
   }));
 }
 
+export async function getGWOTMileEntries(): Promise<GWOTMileEntry[]> {
+  const rows = await fetchCSV(GWOT_MILES_CSV_URL);
+  const data = rows.slice(1);
+
+  return data
+    .map((row) => ({
+      timestamp: row[0],
+      name: row[1],
+      date: row[2],
+      activityType: row[3] as "Walk" | "Ruck" | "Run",
+      miles: parseFloat(row[4]) || 0,
+      notes: row[5] || "",
+    }))
+    .filter((entry) => entry.name && entry.miles > 0);
+}
+
+export function buildGWOTLeaderboard(
+  entries: GWOTMileEntry[],
+): GWOTLeaderboardEntry[] {
+  const totals: Record<
+    string,
+    { walk: number; ruck: number; run: number }
+  > = {};
+
+  for (const entry of entries) {
+    if (!totals[entry.name]) {
+      totals[entry.name] = { walk: 0, ruck: 0, run: 0 };
+    }
+    const type = entry.activityType.toLowerCase() as "walk" | "ruck" | "run";
+    totals[entry.name][type] += entry.miles;
+  }
+
+  return Object.entries(totals)
+    .map(([name, miles]) => ({
+      name,
+      totalMiles: miles.walk + miles.ruck + miles.run,
+      walkMiles: miles.walk,
+      ruckMiles: miles.ruck,
+      runMiles: miles.run,
+    }))
+    .sort((a, b) => b.totalMiles - a.totalMiles);
+}
+
 export function buildLeaderboard(
   submissions: Submission[],
   challenges: Challenge[],
+  gwotLeaderboard?: GWOTLeaderboardEntry[],
 ): LeaderboardEntry[] {
   const pointsMap = new Map<string, number>();
   for (const c of challenges) {
@@ -61,6 +123,15 @@ export function buildLeaderboard(
   for (const sub of submissions) {
     const points = pointsMap.get(sub.challenge) || 0;
     totals[sub.name] = (totals[sub.name] || 0) + points;
+  }
+
+  // Add 10 points for completing 100+ GWOT miles
+  if (gwotLeaderboard) {
+    for (const entry of gwotLeaderboard) {
+      if (entry.totalMiles >= 100) {
+        totals[entry.name] = (totals[entry.name] || 0) + 10;
+      }
+    }
   }
 
   return Object.entries(totals)

--- a/app/profile/[name]/page.tsx
+++ b/app/profile/[name]/page.tsx
@@ -13,6 +13,14 @@ type Props = {
   params: Promise<{ name: string }>;
 };
 
+export type GWOTProgress = {
+  totalMiles: number;
+  walkMiles: number;
+  ruckMiles: number;
+  runMiles: number;
+  completed: boolean;
+};
+
 export type SubmissionWithPoints = {
   challenge: string;
   points: number;
@@ -21,13 +29,6 @@ export type SubmissionWithPoints = {
   rowIndex: number;
 };
 
-export type GWOTProgress = {
-  totalMiles: number;
-  walkMiles: number;
-  ruckMiles: number;
-  runMiles: number;
-  completed: boolean;
-};
 
 export default async function Profile({ params }: Props) {
   const { name: slug } = await params;
@@ -74,7 +75,7 @@ export default async function Profile({ params }: Props) {
 
   // Get GWOT progress for this user
   const gwotEntry = gwotLeaderboard.find((e) => e.name === displayName);
-  const gwotProgress: GWOTProgress = gwotEntry
+  const gwotProgress = gwotEntry
     ? {
         totalMiles: gwotEntry.totalMiles,
         walkMiles: gwotEntry.walkMiles,

--- a/app/profile/[name]/profile-page.tsx
+++ b/app/profile/[name]/profile-page.tsx
@@ -292,11 +292,32 @@ export function ProfilePage({
                 </div>
               </div>
 
-              {!gwotProgress.completed && (
-                <div className="mt-3 pt-3 border-t border-slate-100 text-sm text-slate-500">
-                  {(100 - gwotProgress.totalMiles).toFixed(1)} miles to go!
-                </div>
-              )}
+              {!gwotProgress.completed && (() => {
+                const challengeStart = new Date(2026, 1, 1); // Feb 1, 2026
+                const now = new Date();
+                const daysSinceStart = Math.floor(
+                  (now.getTime() - challengeStart.getTime()) / (1000 * 60 * 60 * 24)
+                );
+                const daysElapsed = Math.max(1, Math.min(28, daysSinceStart));
+                const expectedMiles = daysElapsed * (100 / 28);
+                const net = gwotProgress.totalMiles - expectedMiles;
+                const milesToGo = (100 - gwotProgress.totalMiles).toFixed(1);
+
+                return (
+                  <div className="mt-3 pt-3 border-t border-slate-100 text-sm text-slate-500">
+                    {milesToGo} miles to go —{" "}
+                    {net >= 0 ? (
+                      <span className="text-green-600">
+                        +{net.toFixed(1)} mi ahead of pace
+                      </span>
+                    ) : (
+                      <span className="text-red-500">
+                        {Math.abs(net).toFixed(1)} mi behind pace
+                      </span>
+                    )}
+                  </div>
+                );
+              })()}
             </div>
           </div>
         )}

--- a/app/profile/[name]/profile-page.tsx
+++ b/app/profile/[name]/profile-page.tsx
@@ -209,98 +209,97 @@ export function ProfilePage({
           )}
         </div>
 
-        {/* GWOT Progress Card */}
-        <div className="bg-white rounded-2xl shadow-sm overflow-hidden border-2 border-green-200">
-          <div className="px-4 py-3 bg-green-50 border-b border-green-100 flex items-center gap-2">
-            <FlagBanner size={16} weight="fill" className="text-green-600" />
-            <h2 className="text-xs font-semibold text-green-700 uppercase tracking-wider">
-              GWOT 100 Mile Challenge
-            </h2>
-            {gwotProgress.completed && (
-              <span className="ml-auto bg-green-600 text-white text-xs font-semibold px-2 py-0.5 rounded-full">
-                COMPLETED +10 pts
-              </span>
-            )}
-          </div>
-          <div className="p-4">
-            <div className="flex items-center gap-4">
-              {/* Circular Progress */}
-              <div className="relative w-20 h-20 flex-shrink-0">
-                <svg className="w-20 h-20 transform -rotate-90">
-                  <circle
-                    cx="40"
-                    cy="40"
-                    r="36"
-                    fill="none"
-                    stroke="#e2e8f0"
-                    strokeWidth="8"
-                  />
-                  <circle
-                    cx="40"
-                    cy="40"
-                    r="36"
-                    fill="none"
-                    stroke={gwotProgress.completed ? "#16a34a" : "#22c55e"}
-                    strokeWidth="8"
-                    strokeLinecap="round"
-                    strokeDasharray={`${Math.min(100, (gwotProgress.totalMiles / 100) * 100) * 2.26} 226`}
-                  />
-                </svg>
-                <div className="absolute inset-0 flex items-center justify-center">
-                  <span className="text-lg font-bold text-slate-800">
-                    {Math.min(100, Math.round((gwotProgress.totalMiles / 100) * 100))}%
-                  </span>
-                </div>
-              </div>
-
-              <div className="flex-1">
-                <div className="text-2xl font-bold text-slate-800">
-                  {gwotProgress.totalMiles.toFixed(1)}{" "}
-                  <span className="text-base font-normal text-slate-500">
-                    / 100 miles
-                  </span>
-                </div>
-
-                {/* Activity Breakdown */}
-                <div className="mt-2 flex flex-wrap gap-x-4 gap-y-1 text-sm">
-                  {gwotProgress.walkMiles > 0 && (
-                    <div className="flex items-center gap-1">
-                      <div className="w-2 h-2 rounded-full bg-green-500" />
-                      <span className="text-slate-600">
-                        Walk: {gwotProgress.walkMiles.toFixed(1)}
-                      </span>
-                    </div>
-                  )}
-                  {gwotProgress.ruckMiles > 0 && (
-                    <div className="flex items-center gap-1">
-                      <div className="w-2 h-2 rounded-full bg-blue-500" />
-                      <span className="text-slate-600">
-                        Ruck: {gwotProgress.ruckMiles.toFixed(1)}
-                      </span>
-                    </div>
-                  )}
-                  {gwotProgress.runMiles > 0 && (
-                    <div className="flex items-center gap-1">
-                      <div className="w-2 h-2 rounded-full bg-orange-500" />
-                      <span className="text-slate-600">
-                        Run: {gwotProgress.runMiles.toFixed(1)}
-                      </span>
-                    </div>
-                  )}
-                  {gwotProgress.totalMiles === 0 && (
-                    <span className="text-slate-400">No miles logged yet</span>
-                  )}
-                </div>
-              </div>
+        {/* GWOT Progress Card - Only show if user has logged at least 1 mile */}
+        {gwotProgress.totalMiles > 0 && (
+          <div className="bg-white rounded-2xl shadow-sm overflow-hidden border-2 border-green-200">
+            <div className="px-4 py-3 bg-green-50 border-b border-green-100 flex items-center gap-2">
+              <FlagBanner size={16} weight="fill" className="text-green-600" />
+              <h2 className="text-xs font-semibold text-green-700 uppercase tracking-wider">
+                GWOT 100 Mile Challenge
+              </h2>
+              {gwotProgress.completed && (
+                <span className="ml-auto bg-green-600 text-white text-xs font-semibold px-2 py-0.5 rounded-full">
+                  COMPLETED +10 pts
+                </span>
+              )}
             </div>
+            <div className="p-4">
+              <div className="flex items-center gap-4">
+                {/* Circular Progress */}
+                <div className="relative w-20 h-20 flex-shrink-0">
+                  <svg className="w-20 h-20 transform -rotate-90">
+                    <circle
+                      cx="40"
+                      cy="40"
+                      r="36"
+                      fill="none"
+                      stroke="#e2e8f0"
+                      strokeWidth="8"
+                    />
+                    <circle
+                      cx="40"
+                      cy="40"
+                      r="36"
+                      fill="none"
+                      stroke={gwotProgress.completed ? "#16a34a" : "#22c55e"}
+                      strokeWidth="8"
+                      strokeLinecap="round"
+                      strokeDasharray={`${Math.min(100, (gwotProgress.totalMiles / 100) * 100) * 2.26} 226`}
+                    />
+                  </svg>
+                  <div className="absolute inset-0 flex items-center justify-center">
+                    <span className="text-lg font-bold text-slate-800">
+                      {Math.min(100, Math.round((gwotProgress.totalMiles / 100) * 100))}%
+                    </span>
+                  </div>
+                </div>
 
-            {!gwotProgress.completed && gwotProgress.totalMiles > 0 && (
-              <div className="mt-3 pt-3 border-t border-slate-100 text-sm text-slate-500">
-                {(100 - gwotProgress.totalMiles).toFixed(1)} miles to go!
+                <div className="flex-1">
+                  <div className="text-2xl font-bold text-slate-800">
+                    {gwotProgress.totalMiles.toFixed(1)}{" "}
+                    <span className="text-base font-normal text-slate-500">
+                      / 100 miles
+                    </span>
+                  </div>
+
+                  {/* Activity Breakdown */}
+                  <div className="mt-2 flex flex-wrap gap-x-4 gap-y-1 text-sm">
+                    {gwotProgress.walkMiles > 0 && (
+                      <div className="flex items-center gap-1">
+                        <div className="w-2 h-2 rounded-full bg-green-500" />
+                        <span className="text-slate-600">
+                          Walk: {gwotProgress.walkMiles.toFixed(1)}
+                        </span>
+                      </div>
+                    )}
+                    {gwotProgress.ruckMiles > 0 && (
+                      <div className="flex items-center gap-1">
+                        <div className="w-2 h-2 rounded-full bg-blue-500" />
+                        <span className="text-slate-600">
+                          Ruck: {gwotProgress.ruckMiles.toFixed(1)}
+                        </span>
+                      </div>
+                    )}
+                    {gwotProgress.runMiles > 0 && (
+                      <div className="flex items-center gap-1">
+                        <div className="w-2 h-2 rounded-full bg-orange-500" />
+                        <span className="text-slate-600">
+                          Run: {gwotProgress.runMiles.toFixed(1)}
+                        </span>
+                      </div>
+                    )}
+                  </div>
+                </div>
               </div>
-            )}
+
+              {!gwotProgress.completed && (
+                <div className="mt-3 pt-3 border-t border-slate-100 text-sm text-slate-500">
+                  {(100 - gwotProgress.totalMiles).toFixed(1)} miles to go!
+                </div>
+              )}
+            </div>
           </div>
-        </div>
+        )}
 
         {/* Submissions Audit Log */}
         <div className="bg-white rounded-2xl shadow-sm overflow-hidden">

--- a/app/profile/[name]/profile-page.tsx
+++ b/app/profile/[name]/profile-page.tsx
@@ -10,8 +10,9 @@ import {
   Note,
   X,
   ArrowSquareOut,
+  FlagBanner,
 } from "@phosphor-icons/react";
-import type { SubmissionWithPoints } from "./page";
+import type { SubmissionWithPoints, GWOTProgress } from "./page";
 
 const PODIUM_LEVELS = [
   { name: "Bronze", points: 50, color: "text-orange-500", bg: "bg-orange-500" },
@@ -111,6 +112,7 @@ type Props = {
   rank: number;
   totalParticipants: number;
   submissions: SubmissionWithPoints[];
+  gwotProgress: GWOTProgress;
 };
 
 export function ProfilePage({
@@ -119,6 +121,7 @@ export function ProfilePage({
   rank,
   totalParticipants,
   submissions,
+  gwotProgress,
 }: Props) {
   const [selectedNotes, setSelectedNotes] = useState<{
     notes: string;
@@ -204,6 +207,99 @@ export function ProfilePage({
               </div>
             </div>
           )}
+        </div>
+
+        {/* GWOT Progress Card */}
+        <div className="bg-white rounded-2xl shadow-sm overflow-hidden border-2 border-green-200">
+          <div className="px-4 py-3 bg-green-50 border-b border-green-100 flex items-center gap-2">
+            <FlagBanner size={16} weight="fill" className="text-green-600" />
+            <h2 className="text-xs font-semibold text-green-700 uppercase tracking-wider">
+              GWOT 100 Mile Challenge
+            </h2>
+            {gwotProgress.completed && (
+              <span className="ml-auto bg-green-600 text-white text-xs font-semibold px-2 py-0.5 rounded-full">
+                COMPLETED +10 pts
+              </span>
+            )}
+          </div>
+          <div className="p-4">
+            <div className="flex items-center gap-4">
+              {/* Circular Progress */}
+              <div className="relative w-20 h-20 flex-shrink-0">
+                <svg className="w-20 h-20 transform -rotate-90">
+                  <circle
+                    cx="40"
+                    cy="40"
+                    r="36"
+                    fill="none"
+                    stroke="#e2e8f0"
+                    strokeWidth="8"
+                  />
+                  <circle
+                    cx="40"
+                    cy="40"
+                    r="36"
+                    fill="none"
+                    stroke={gwotProgress.completed ? "#16a34a" : "#22c55e"}
+                    strokeWidth="8"
+                    strokeLinecap="round"
+                    strokeDasharray={`${Math.min(100, (gwotProgress.totalMiles / 100) * 100) * 2.26} 226`}
+                  />
+                </svg>
+                <div className="absolute inset-0 flex items-center justify-center">
+                  <span className="text-lg font-bold text-slate-800">
+                    {Math.min(100, Math.round((gwotProgress.totalMiles / 100) * 100))}%
+                  </span>
+                </div>
+              </div>
+
+              <div className="flex-1">
+                <div className="text-2xl font-bold text-slate-800">
+                  {gwotProgress.totalMiles.toFixed(1)}{" "}
+                  <span className="text-base font-normal text-slate-500">
+                    / 100 miles
+                  </span>
+                </div>
+
+                {/* Activity Breakdown */}
+                <div className="mt-2 flex flex-wrap gap-x-4 gap-y-1 text-sm">
+                  {gwotProgress.walkMiles > 0 && (
+                    <div className="flex items-center gap-1">
+                      <div className="w-2 h-2 rounded-full bg-green-500" />
+                      <span className="text-slate-600">
+                        Walk: {gwotProgress.walkMiles.toFixed(1)}
+                      </span>
+                    </div>
+                  )}
+                  {gwotProgress.ruckMiles > 0 && (
+                    <div className="flex items-center gap-1">
+                      <div className="w-2 h-2 rounded-full bg-blue-500" />
+                      <span className="text-slate-600">
+                        Ruck: {gwotProgress.ruckMiles.toFixed(1)}
+                      </span>
+                    </div>
+                  )}
+                  {gwotProgress.runMiles > 0 && (
+                    <div className="flex items-center gap-1">
+                      <div className="w-2 h-2 rounded-full bg-orange-500" />
+                      <span className="text-slate-600">
+                        Run: {gwotProgress.runMiles.toFixed(1)}
+                      </span>
+                    </div>
+                  )}
+                  {gwotProgress.totalMiles === 0 && (
+                    <span className="text-slate-400">No miles logged yet</span>
+                  )}
+                </div>
+              </div>
+            </div>
+
+            {!gwotProgress.completed && gwotProgress.totalMiles > 0 && (
+              <div className="mt-3 pt-3 border-t border-slate-100 text-sm text-slate-500">
+                {(100 - gwotProgress.totalMiles).toFixed(1)} miles to go!
+              </div>
+            )}
+          </div>
         </div>
 
         {/* Submissions Audit Log */}

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "eslint": "^9",
         "eslint-config-next": "16.1.1",
         "tailwindcss": "^4",
-        "typescript": "^5"
+        "typescript": "5.9.3"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -68,7 +68,6 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -1576,7 +1575,6 @@
       "integrity": "sha512-MWtvHrGZLFttgeEj28VXHxpmwYbor/ATPYbBfSFZEIRK0ecCFLl2Qo55z52Hss+UV9CRN7trSeq1zbgx7YDWWg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -1636,7 +1634,6 @@
       "integrity": "sha512-hM5faZwg7aVNa819m/5r7D0h0c9yC4DUlWAOvHAtISdFTc8xB86VmX5Xqabrama3wIPJ/q9RbGS1worb6JfnMg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.50.1",
         "@typescript-eslint/types": "8.50.1",
@@ -2136,7 +2133,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2477,7 +2473,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -3045,7 +3040,6 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3231,7 +3225,6 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -5404,7 +5397,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.3.tgz",
       "integrity": "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -5414,7 +5406,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -6103,7 +6094,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -6266,7 +6256,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -6542,7 +6531,6 @@
       "integrity": "sha512-0wZ1IRqGGhMP76gLqz8EyfBXKk0J2qo2+H3fi4mcUP/KtTocoX08nmIAHl1Z2kJIZbZee8KOpBCSNPRgauucjw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -24,6 +24,6 @@
     "eslint": "^9",
     "eslint-config-next": "16.1.1",
     "tailwindcss": "^4",
-    "typescript": "^5"
+    "typescript": "5.9.3"
   }
 }


### PR DESCRIPTION
### 👋 TL;DR
Remove the GWOT 100-Mile Challenge tab from the UI now that February is over. GWOT bonus points (10 pts for 100+ miles) are preserved in the leaderboard, and the GWOT Progress Card remains on individual profile pages.

### 🔎 Details
- Removed GWOT tab from desktop and mobile navigation
- Removed `GWOTContent` and `GWOTSubmitModal` components from dashboard
- Removed `/gwot` route and `/gwot/log-miles` modal trigger
- Kept GWOT data fetch + `buildLeaderboard()` integration so completers keep their 10 bonus points
- Kept GWOT Progress Card on profile pages for completed participants

### ✅ How to Test
1. Verify GWOT tab no longer appears in desktop or mobile navigation
2. Navigate to `/gwot` — should fall through to home tab (no longer a valid route)
3. Check that users who completed 100+ miles still show correct points on leaderboard
4. Visit a profile of a GWOT completer — GWOT Progress Card still shows, points still correct

### 🥜 GIF
![done](https://media.giphy.com/media/l0MYt5jPR6QX5pnqM/giphy.gif)